### PR TITLE
Be easy on the memory

### DIFF
--- a/chunker/tests.py
+++ b/chunker/tests.py
@@ -34,14 +34,6 @@ class ChunkerTestCase(TestCase):
             )
         ]
 
-    def test__set_chunks(self):
-        self.chunker._set_chunks('test', self.test_string)
-
-        self.assertEqual(self.chunker.client.get('test-0'), 'aaaaaaaaaa')
-        self.assertEqual(self.chunker.client.get('test-1'), 'bbbbbbbbbb')
-        self.assertEqual(self.chunker.client.get('test-2'), 'cccccccccc')
-        self.assertEqual(self.chunker.client.get('test-3'), 'dddddd')
-
     def test_set_file(self):
         with tempfile.NamedTemporaryFile() as f:
             f.write(self.test_string)

--- a/chunker/tests.py
+++ b/chunker/tests.py
@@ -44,6 +44,7 @@ class ChunkerTestCase(TestCase):
         self.assertEqual(self.chunker.client.get('test-1'), 'bbbbbbbbbb')
         self.assertEqual(self.chunker.client.get('test-2'), 'cccccccccc')
         self.assertEqual(self.chunker.client.get('test-3'), 'dddddd')
+        self.assertEqual(self.chunker.client.get('test-4'), None)
 
         self.assertEqual(self.chunker.client.get('test-metadata'), ','.join(self.hashes))
 
@@ -59,6 +60,7 @@ class ChunkerTestCase(TestCase):
         self.assertEqual(chunks[1], 'bbbbbbbbbb')
         self.assertEqual(chunks[2], 'cccccccccc')
         self.assertEqual(chunks[3], 'dddddd')
+        self.assertEqual(len(chunks), 4)
 
     def test_get_file(self):
         with tempfile.NamedTemporaryFile() as f:

--- a/chunker_profile.py
+++ b/chunker_profile.py
@@ -1,0 +1,30 @@
+# System imports
+from memory_profiler import profile
+
+# Local imports
+from chunker.client import Chunker
+
+
+@profile
+def run_profile_test(file_path, chunk_size):
+    chunker = Chunker('localhost', 11211, chunk_size)
+    chunker.set_file('profiler', file_path)
+
+
+if __name__ == '__main__':
+    chunk_size = 1000 ** 2
+
+    file_path = 'chunker/test_file.txt'
+
+    # pr = cProfile.Profile()
+    # pr.enable()
+
+    run_profile_test(file_path, chunk_size)
+
+    # pr.disable()
+
+    # s = StringIO.StringIO()
+    # sortby = 'cumulative'
+    # ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
+    # ps.print_stats()
+    # print s.getvalue()

--- a/chunker_profile.py
+++ b/chunker_profile.py
@@ -1,5 +1,6 @@
 # System imports
 from memory_profiler import profile
+import os
 
 # Local imports
 from chunker.client import Chunker
@@ -9,6 +10,8 @@ from chunker.client import Chunker
 def run_profile_test(file_path, chunk_size):
     chunker = Chunker('localhost', 11211, chunk_size)
     chunker.set_file('profiler', file_path)
+    chunker.get_file('profiler', 'test_file')
+    os.remove('test_file')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Read only chunk size at a time from the file. This consumes less memory.
2. Improvement of test to assert that only the expected keys are present
3. Add test file and code for profiling `set_file` and `get_file`.

Thanks a lot @Katee for your work on this!